### PR TITLE
fixes #20

### DIFF
--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -14,7 +14,7 @@ class EventCard extends StatelessWidget {
     return new Padding(
       padding: new EdgeInsets.symmetric(vertical: 15.0, horizontal: 5.0),
         child: new Card(
-        color: Colors.white,
+        margin: new EdgeInsets.all(0.0),
         child: new Column(
           children: <Widget>[
             new Container(


### PR DESCRIPTION
The white border was caused by small margin that is default to the card widget.